### PR TITLE
TSK-842: Fix date-query and enable queries for day, month and year

### DIFF
--- a/lib/taskana-simplehistory-rest-spring-example/src/main/resources/application.properties
+++ b/lib/taskana-simplehistory-rest-spring-example/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-logging.level.pro.taskana=INFO
+logging.level.pro.taskana=DEBUG
 taskana.schemaName=TASKANA

--- a/lib/taskana-simplehistory-rest-spring-example/src/test/java/pro/taskana/rest/simplehistory/TaskHistoryEventControllerIntTest.java
+++ b/lib/taskana-simplehistory-rest-spring-example/src/test/java/pro/taskana/rest/simplehistory/TaskHistoryEventControllerIntTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.SQLException;
+import java.time.LocalDateTime;
 import java.util.Collections;
 
 import javax.sql.DataSource;
@@ -128,6 +129,31 @@ public class TaskHistoryEventControllerIntTest {
             assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
             assertTrue(e.getResponseBodyAsString().contains("[invalid]"));
         }
+    }
+
+    @Test
+    public void testGetHistoryEventOfDate() {
+        String currentTime = LocalDateTime.now().toString();
+
+        try {
+            template.exchange(
+                server + port + "/v1/task-history-event?created=" + currentTime, HttpMethod.GET, request,
+                new ParameterizedTypeReference<PagedResources<TaskHistoryEventResource>>() {
+                });
+            fail();
+        } catch (HttpClientErrorException e) {
+            assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+            assertTrue(e.getResponseBodyAsString().contains(currentTime));
+        }
+
+        //correct Format 'yyyy-MM-dd'
+        currentTime = currentTime.substring(0, 10);
+        ResponseEntity<PagedResources<TaskHistoryEventResource>> response = template.exchange(
+            server + port + "/v1/task-history-event?created=" + currentTime, HttpMethod.GET, request,
+            new ParameterizedTypeReference<PagedResources<TaskHistoryEventResource>>() {
+            });
+        assertNotNull(response.getBody().getLink(Link.REL_SELF));
+        assertEquals(25, response.getBody().getContent().size());
     }
 
     @Test

--- a/lib/taskana-simplehistory-rest-spring/src/main/java/pro/taskana/rest/simplehistory/TaskHistoryEventController.java
+++ b/lib/taskana-simplehistory-rest-spring/src/main/java/pro/taskana/rest/simplehistory/TaskHistoryEventController.java
@@ -1,7 +1,8 @@
 package pro.taskana.rest.simplehistory;
 
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -267,9 +268,7 @@ public class TaskHistoryEventController extends AbstractPagingController {
         }
         if (params.containsKey(CREATED)) {
             String[] created = extractCommaSeparatedFields(params.get(CREATED));
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-            Instant date = Instant.from(formatter.parse(created[0]));
-            TimeInterval timeInterval = new TimeInterval(date, date);
+            TimeInterval timeInterval = getTimeIntervalOf(created);
             query.createdWithin(timeInterval);
             params.remove(CREATED);
         }
@@ -408,5 +407,24 @@ public class TaskHistoryEventController extends AbstractPagingController {
         }
 
         return query;
+    }
+
+    private TimeInterval getTimeIntervalOf(String[] created) {
+        LocalDate begin;
+        LocalDate end;
+        try {
+            begin = LocalDate.parse(created[0]);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot parse String '" + created[0] + "'. Expected a String of the Format 'yyyy-MM-dd'.");
+        }
+        if (created.length < 2) {
+            end = begin.plusDays(1);
+        } else {
+            end = LocalDate.parse(created[1]);
+        }
+        Instant beginInst = begin.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Instant endInst = end.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        TimeInterval timeInterval = new TimeInterval(beginInst, endInst);
+        return timeInterval;
     }
 }


### PR DESCRIPTION
At the moment the "created"-request does not work, because the translation from String to Instant is broken.

Additionally it can be queryied for a year, a month or a day.
Maybe we should remove the old query-functionality because it only queries for a specified second.